### PR TITLE
Feature: add support for superagent plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,19 @@ Here's what's on the list to add:
 - Includes a default PUT action (called put).
 - Transforms are passed a headers object as the second argument, rather than a getter.
 - Superagent will automatically parse certain response types. This is not suppressed by passing a responseTransform of [].
+
+## Superagent Plugins
+
+Additionally to the angular resource options, [superagent plugins](https://github.com/visionmedia/superagent#plugins) can be configured for each resource action.
+
+```
+var nocache = require('superagent-no-cache');
+var prefix = require('superagent-prefix');
+
+var myResource = superRes.resource('/my-endpoint/:id', {
+  action: {
+    method: 'GET',
+    plugins: [nocache, prefix('/static')]
+  }
+})
+```

--- a/src/actionDefaults.js
+++ b/src/actionDefaults.js
@@ -4,5 +4,6 @@ export default actionDefaults = {
   transformRequest: [],
   transformResponse: [],
   withCredentials: false,
-  cache: null
+  cache: null,
+  plugins: []
 };

--- a/src/superagentAdapter.js
+++ b/src/superagentAdapter.js
@@ -9,6 +9,13 @@ exports.configureRequest = function configureRequest(config, url, dataTransforme
   const method = config.method.toLowerCase();
   let currentRequest = request[method === 'delete' ? 'del' : method](url);
 
+  // Setup superagent plugins
+  if (config.plugins && config.plugins.length) {
+    config.plugins.forEach((plugin) => {
+      currentRequest = currentRequest.use(plugin);
+    });
+  }
+
   currentRequest = currentRequest.accept(config.responseType);
   if (config.headers) {
     currentRequest = currentRequest.set(config.headers);

--- a/test/unit/superagentAdapter.js
+++ b/test/unit/superagentAdapter.js
@@ -6,6 +6,7 @@ describe('superagentAdapter: ', () => {
   let ResourceAction;
   let stubs;
   let cacheStub;
+  let plugin;
 
   beforeEach(() => {
     stubs = {
@@ -20,7 +21,8 @@ describe('superagentAdapter: ', () => {
         end: stub().returnsThis(),
         clearTimeout: stub().returnsThis(),
         timeout: stub().returnsThis(),
-        withCredentials: stub().returnsThis()
+        withCredentials: stub().returnsThis(),
+        use: stub().returnsThis(),
       }
     };
 
@@ -258,6 +260,26 @@ describe('superagentAdapter: ', () => {
 
     it('should have called withCredentials', () => {
       expect(stubs.superagent.withCredentials.called).to.be.true;
+    });
+
+  });
+
+  describe('request with superagent plugin', () => {
+    let result;
+
+    const url = 'http://example.com/posts/';
+    beforeEach(() => {
+      plugin = function(){}
+
+      result = adapter.configureRequest({
+        method: 'GET',
+        plugins: [plugin]
+      }, (new Route(url)).reverse(), () => null);
+    });
+
+    it('should have called use', () => {
+      expect(stubs.superagent.use.called).to.be.true;
+      expect(stubs.superagent.use.calledWith(plugin)).to.be.true;
     });
 
   });


### PR DESCRIPTION
Adds support for configuring superagent plugins per resource action. 

```
var nocache = require('superagent-no-cache');
var prefix = require('superagent-prefix');

var myResource = superRes.resource('/my-endpoint/:id', {
  action: {
    method: 'GET',
    plugins: [nocache, prefix('/static')]
  }
})
```

Closes #5 
